### PR TITLE
Fix pinact CI rate limit + bump auto-release to Node 24

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -46,15 +46,20 @@ autolabeler:
     files:
       - '*.md'
   - label: 'enhancement'
-    title: '/enhancement|fixes/i'
+    title:
+      - '/enhancement|fixes/i'
   - label: 'upgrades'
-    title: '/⬆️/i'
+    title:
+      - '/⬆️/i'
   - label: 'bug'
-    title: '/🐛|🐞|bug|bugfix/i'
+    title:
+      - '/🐛|🐞|bug|bugfix/i'
   - label: 'auto-update'
-    title: '/🤖/i'
+    title:
+      - '/🤖/i'
   - label: 'feature'
-    title: '/🚀|🎉/i'
+    title:
+      - '/🚀|🎉/i'
 change-template: |
   <details>
     <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -18,16 +18,21 @@ jobs:
       contents: write # release-drafter drafts the next release
       pull-requests: write # autolabeler labels PRs
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5.25.0
+      # Drafter on main pushes; autolabeler on PRs (separate actions since release-drafter v7)
+      - name: Draft release notes
+        if: github.event_name == 'push' && github.ref_name == 'main'
+        uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         with:
           publish: false
           prerelease: true
           config-name: auto-release.yml
-          # allows autolabeler to run without unmerged PRs from being added to draft
-          disable-releaser: ${{ github.ref_name != 'main' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Autolabel PRs
+        if: github.event_name == 'pull_request'
+        uses: release-drafter/release-drafter/autolabeler@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+        with:
+          config-name: auto-release.yml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,6 +56,7 @@ jobs:
         env:
           REF_NAME: ${{ github.ref_name }} # via env, never interpolated into the shell (zizmor: template-injection)
           EVENT_NAME: ${{ github.event_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # used by pinact to verify pinned action annotations
         run: |
           if [ "$EVENT_NAME" = "pull_request" ]; then
             if ! mise run check --pr; then

--- a/hk.pkl
+++ b/hk.pkl
@@ -40,7 +40,10 @@ local linters: Mapping<String, Step> = new Mapping<String, Step> {
   // GitHub Actions
   ["actionlint"] = Builtins.actionlint
   ["zizmor"] = Builtins.zizmor
-  ["pinact"] = Builtins.pinact
+  ["pinact"] = (Builtins.pinact) {
+    check_diff = "PINACT_GITHUB_TOKEN=\"${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}\" " + Builtins.pinact.check_diff
+    fix = "PINACT_GITHUB_TOKEN=\"${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}\" " + Builtins.pinact.fix
+  }
 
   // Secrets & spelling
   ["betterleaks"] = Builtins.betterleaks


### PR DESCRIPTION
### Summary

<!-- pr:summary -->

Pass `GITHUB_TOKEN` into the lint `Run check` step so pinact `--verify` is authenticated, and bump auto-release action pins off Node-20 runtimes.

**Changes** <!-- pr:changes -->

- **Fixed**: daily lint schedule no longer hits anonymous GitHub API 403s from pinact
- **Upgraded**: `actions/checkout` v2 → v6.0.3 (SHA matches sibling alfred repos)
- **Upgraded**: `release-drafter` v5 → v7.5.1 (`node24`); split drafter vs autolabeler steps (v7 removed `disable-releaser`)

<details><summary>Tests & Validation</summary>

- Pre-commit hooks (actionlint, zizmor, pinact `--verify`, yamllint) passed on the auto-release change
- Did not run full `mise run check --all` (untrusted mise / no `mise trust` per constraint)

</details>

### Relevant Links

<!-- pr:links -->

- Failed run: https://github.com/sherifabdlnaby/alfred-aws-granted/actions/runs/29132298365

---

_<sub>🤖 Created with Cursor (Grok 4.5) on behalf of @sherifabdlnaby, fully autonomous, they have not reviewed this.</sub>_