### PR TITLE
Harden mise lint rules + fix CI --pr trust theatre

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,14 @@ on:
   schedule:
     # Daily sweep so the default branch can't quietly rot.
     - cron: "0 0 * * *"
-  # Run manually.
-  workflow_dispatch: {}
+  # Run manually — pick the scope: --all (whole tree) or --pr (this branch's diff vs the default branch).
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: "Files to check"
+        type: choice
+        options: [all, pr]
+        default: all
 # Read the repo; comment on PRs to point the author at the fix command.
 permissions:
   contents: read
@@ -40,35 +46,26 @@ jobs:
           experimental: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # SO tool installs don't hit API rate limits
-      # `check --pr` diffs against the default branch, but a pull_request checkout only has
-      # it as `origin/<base>` (HEAD is detached on the merge commit). Materialize a local
-      # branch so hk can resolve the ref instead of failing with "Failed to parse reference".
-      - name: Make base branch resolvable for `check --pr`
-        if: github.event_name == 'pull_request'
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }} # via env, not interpolated into the shell
-        run: git branch --force "$BASE_REF" "origin/$BASE_REF"
-      # Report only — the same `check` task local dev and the pre-commit hook run. We do NOT
-      # auto-fix in CI; on failure we point the author at `--fix` (see the comment step below).
-      # `--pr` scopes to changed files; `--all` covers the whole tree on schedule/dispatch.
+      # Report only — same `check` task local dev and the pre-commit hook run; we do NOT auto-fix
+      # in CI. On failure, emit a `::error::` pointing the author at `--fix` (see the comment step).
       - name: Run check
         id: check
         env:
-          REF_NAME: ${{ github.ref_name }} # via env, never interpolated into the shell (zizmor: template-injection)
-          EVENT_NAME: ${{ github.event_name }}
+          EVENT: ${{ github.event_name }} # via env, never interpolated (zizmor: template-injection)
+          SCOPE_INPUT: ${{ inputs.scope }} # 'all'|'pr' on manual dispatch; empty on PR/schedule
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
+          REF_NAME: ${{ github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # used by pinact to verify pinned action annotations
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            if ! mise run check --pr; then
-              echo "::error::Lint & format failed. Fix it locally with 'mise run check --fix --pr', then push. ('mise run setup' installs the pre-commit hook so this happens automatically.)"
-              exit 1
-            fi
-          else
-            if ! mise run check --all; then
-              echo "::error::Lint & format failed on $REF_NAME. Fix it with 'mise run check --fix --all'."
-              exit 1
-            fi
-          fi
+          # PRs check changed files (--pr); schedule/dispatch default to --all (dispatch can pick --pr).
+          [ "$EVENT" = pull_request ] && scope="pr" || scope="${SCOPE_INPUT:-all}"
+          # hk's --pr resolves the base via origin/HEAD, which the Actions checkout never sets; point it
+          # at the PR base so hk diffs origin/<base>...HEAD (else it finds 0 files and passes green).
+          [ "$scope" = "pr" ] && git remote set-head origin "$BASE_REF" >/dev/null 2>&1 || true
+          mise run check "--$scope" || {
+            echo "::error::Lint & format failed on $REF_NAME — fix locally with 'mise run check --fix --$scope', then push. ('mise run setup' installs the pre-commit hook so this happens on every commit.)"
+            exit 1
+          }
       # One sticky PR comment pointing at `--fix`: post/update it when the check fails,
       # delete it once the check passes. No inline suggestions — the author runs the fixer.
       - name: Comment lint status

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Changing tools, tasks, env, or hooks? Edit the config, don't bolt on scripts, th
 
 - **`mise.toml`**: the source of truth for `[tools]`, `[tasks]`, `[vars]`, `[settings]`, and `[hooks]`.
 - **`mise.lock`**: resolved versions plus checksums. Commit it; regenerate with `mise install` then `mise lock --platform macos-arm64,linux-x64` after a `[tools]` change.
-- **`.mise/`**: project-local state (gitignored), like the setup stamp the `setup`/`enter` hooks read.
+- **`.mise/`**: project-local state (the `setup` stamp is gitignored; the directory is committed so the stamp has a home).
 - **`hk.pkl`**: the pre-commit and `check` pipeline (linters and formatters, in Pkl). Add or edit a lint step here.
 - Linter config scaffolds live at the repo root (`typos.toml`, `.betterleaks.toml`, `lychee.toml`, `rumdl.toml`, `.yamllint`).
 

--- a/README.md
+++ b/README.md
@@ -49,15 +49,32 @@ This is a **data-only** Alfred workflow: it's `info.plist`, `regions.json`, `ser
 
 The project uses [**mise**](https://mise.jdx.dev) to pin its lint/format tools, expose tasks, and wire git hooks (no language runtime is needed).
 
-1. **Install mise** — see the [getting-started guide](https://mise.jdx.dev/getting-started.html) (e.g. `curl https://mise.run | sh`).
-2. **Set up the repo** (once, and per new clone/worktree):
+<details>
+<summary><b>Install mise</b> (first time on this machine)</summary>
+
+```sh
+brew install mise   # macOS / Linux (Homebrew)
+# or: apt / dnf / pacman — see https://mise.jdx.dev/installing-mise.html
+```
+
+Activate it in your shell, then confirm:
+
+```sh
+echo 'eval "$(mise activate zsh)"' >> ~/.zshrc   # zsh; use bashrc for bash
+# restart the shell
+mise doctor
+```
+
+</details>
+
+1. **Set up the repo** (once, and per new clone/worktree):
 
    ```sh
    mise trust && mise run setup
    ```
 
    `setup` installs the pinned tools and, via the `postinstall` hook, the [hk](https://hk.jdx.dev) pre-commit hook.
-3. **Common tasks:**
+2. **Common tasks:**
 
    ```sh
    mise run check          # run all linters/formatters (alias: lint); add --fix to auto-fix

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,6 +1,6 @@
 // hk.pkl — git hooks for hk. See https://hk.jdx.dev. Pinned to the installed hk (`hk version`).
-amends "package://github.com/jdx/hk/releases/download/v1.47.0/hk@1.47.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.47.0/hk@1.47.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 // Repo-wide ignores — committed paths only (.gitignore is already honored).
 // Excludes binary assets (no text linter applies) and build artifacts from every step.
@@ -72,6 +72,14 @@ hooks {
   // `git push` — no-op; add slower gates here.
   ["pre-push"] {
     steps {
+      // ["test"] { check = "mise run test" }
+    }
+  }
+
+  // Commit message ({{commit_msg_file}}) — no-op.
+  ["commit-msg"] {
+    steps {
+      // ["conventional-commit"] = Builtins.check_conventional_commit
     }
   }
 }

--- a/mise.lock
+++ b/mise.lock
@@ -7,11 +7,13 @@ backend = "aqua:rhysd/actionlint"
 [tools.actionlint."platforms.linux-x64"]
 checksum = "sha256:8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924896"
 provenance = "github-attestations"
 
 [tools.actionlint."platforms.macos-arm64"]
 checksum = "sha256:aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f"
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924893"
 provenance = "github-attestations"
 
 [[tools.betterleaks]]
@@ -21,24 +23,28 @@ backend = "aqua:betterleaks/betterleaks"
 [tools.betterleaks."platforms.linux-x64"]
 checksum = "sha256:b883e8c61a3a14c90ff46a08c203cf88fe340ed88251d4c049db5530ec0ac54b"
 url = "https://github.com/betterleaks/betterleaks/releases/download/v1.5.0/betterleaks_1.5.0_linux_x64.tar.gz"
+url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/445900064"
 provenance = "cosign"
 
 [tools.betterleaks."platforms.macos-arm64"]
 checksum = "sha256:a341e534f152bd10fa8309d74e2ab7eadb634f16ddeb7c3f43ca54f8a016905b"
 url = "https://github.com/betterleaks/betterleaks/releases/download/v1.5.0/betterleaks_1.5.0_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/445900061"
 provenance = "cosign"
 
 [[tools.hk]]
-version = "1.47.0"
+version = "1.49.0"
 backend = "aqua:jdx/hk"
 
 [tools.hk."platforms.linux-x64"]
-checksum = "sha256:4b10b3f9ecf5b95035f96ce45fd58cab81b255b894c52c4651e444e2f7a261f6"
-url = "https://github.com/jdx/hk/releases/download/v1.47.0/hk-x86_64-unknown-linux-gnu.tar.gz"
+checksum = "sha256:409c24b22c7f0c2f32be9330defbef54adf71aa53ec13853e20ac0ea952061d6"
+url = "https://github.com/jdx/hk/releases/download/v1.49.0/hk-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/hk/releases/assets/463689407"
 
 [tools.hk."platforms.macos-arm64"]
-checksum = "sha256:3c2a5c8af797bfe7c6f91930966135d62d06222fafbfd3ecaba3eb2d48943ac3"
-url = "https://github.com/jdx/hk/releases/download/v1.47.0/hk-aarch64-apple-darwin.tar.gz"
+checksum = "sha256:2a5b302b97107c036bc7362cd6d8d0501dbb1b735db07c70bc1231a6fe90df44"
+url = "https://github.com/jdx/hk/releases/download/v1.49.0/hk-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/hk/releases/assets/463689399"
 
 [[tools.lychee]]
 version = "0.24.2"
@@ -47,10 +53,12 @@ backend = "aqua:lycheeverse/lychee"
 [tools.lychee."platforms.linux-x64"]
 checksum = "sha256:73657a111819a30c47c08352896796f23d64e4eb2b3ed39b6d32149241566fc5"
 url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/lycheeverse/lychee/releases/assets/409959271"
 
 [tools.lychee."platforms.macos-arm64"]
 checksum = "sha256:c9d3740ea2d891854d37116c9fba840f37b6e7c89d330e7db84ac333631c4977"
 url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/lycheeverse/lychee/releases/assets/409957951"
 
 [[tools.pinact]]
 version = "4.1.0"
@@ -59,11 +67,13 @@ backend = "aqua:suzuki-shunsuke/pinact"
 [tools.pinact."platforms.linux-x64"]
 checksum = "sha256:8fcbf1b3e95551c82fd995535e3c1defa70e23299ce36eb3afd6c98778de6ca0"
 url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.1.0/pinact_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/suzuki-shunsuke/pinact/releases/assets/442249966"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.macos-arm64"]
 checksum = "sha256:b670063ccfa178cdb5c7107d14e3de896f10b93edcc7dbe38b840cb99f2536db"
 url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.1.0/pinact_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/suzuki-shunsuke/pinact/releases/assets/442249963"
 provenance = "github-attestations"
 
 [[tools.prettier]]
@@ -77,11 +87,13 @@ backend = "aqua:rvben/rumdl"
 [tools.rumdl."platforms.linux-x64"]
 checksum = "sha256:1cd2328d17c773387ccbf39068fb4a3689d4a4fa68c75406ba42f66d3a6db0f9"
 url = "https://github.com/rvben/rumdl/releases/download/v0.2.16/rumdl-v0.2.16-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/446488892"
 provenance = "github-attestations"
 
 [tools.rumdl."platforms.macos-arm64"]
 checksum = "sha256:ccd18de0460e549beff672b8ef99f6a083e961aebd779138b460b32ae2de1946"
 url = "https://github.com/rvben/rumdl/releases/download/v0.2.16/rumdl-v0.2.16-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/446488894"
 provenance = "github-attestations"
 
 [[tools.shellcheck]]
@@ -91,10 +103,12 @@ backend = "aqua:koalaman/shellcheck"
 [tools.shellcheck."platforms.linux-x64"]
 checksum = "sha256:8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056942"
 
 [tools.shellcheck."platforms.macos-arm64"]
 checksum = "sha256:56affdd8de5527894dca6dc3d7e0a99a873b0f004d7aabc30ae407d3f48b0a79"
 url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.darwin.aarch64.tar.xz"
+url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056932"
 
 [[tools.taplo]]
 version = "0.10.0"
@@ -102,9 +116,11 @@ backend = "aqua:tamasfe/taplo"
 
 [tools.taplo."platforms.linux-x64"]
 url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz"
+url_api = "https://api.github.com/repos/tamasfe/taplo/releases/assets/257322600"
 
 [tools.taplo."platforms.macos-arm64"]
 url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-darwin-aarch64.gz"
+url_api = "https://api.github.com/repos/tamasfe/taplo/releases/assets/257323110"
 
 [[tools.typos]]
 version = "1.47.2"
@@ -113,10 +129,12 @@ backend = "aqua:crate-ci/typos"
 [tools.typos."platforms.linux-x64"]
 checksum = "sha256:7aef58932fc123b4cf4b40d86468e89a3297d80169051d7cfd13a235e05fc426"
 url = "https://github.com/crate-ci/typos/releases/download/v1.47.2/typos-v1.47.2-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/crate-ci/typos/releases/assets/437792357"
 
 [tools.typos."platforms.macos-arm64"]
 checksum = "sha256:23ca24a9186b5cb395b5f6c8eea8cdb02911c8980833e016454b56e90c3bd474"
 url = "https://github.com/crate-ci/typos/releases/download/v1.47.2/typos-v1.47.2-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/crate-ci/typos/releases/assets/437791803"
 
 [[tools.uv]]
 version = "0.9.30"
@@ -125,11 +143,13 @@ backend = "aqua:astral-sh/uv"
 [tools.uv."platforms.linux-x64"]
 checksum = "sha256:1caf8fe092e2005dd4c134ba515c1aa3eea3d3c143f8a1903bcb58fcdf169365"
 url = "https://github.com/astral-sh/uv/releases/download/0.9.30/uv-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/uv/releases/assets/350792501"
 provenance = "github-attestations"
 
 [tools.uv."platforms.macos-arm64"]
 checksum = "sha256:03a5d9ec7f7d588446b2ec226d13ff6300055e55365eca8f3fab39f342b0e805"
 url = "https://github.com/astral-sh/uv/releases/download/0.9.30/uv-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/uv/releases/assets/350792440"
 provenance = "github-attestations"
 
 [[tools.yamlfmt]]
@@ -139,10 +159,12 @@ backend = "aqua:google/yamlfmt"
 [tools.yamlfmt."platforms.linux-x64"]
 checksum = "sha256:1f300d9257b232bb3b541d7fb1b0e6b3c121bcbab381c86cd38cb8722be8a566"
 url = "https://github.com/google/yamlfmt/releases/download/v0.21.0/yamlfmt_0.21.0_Linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/google/yamlfmt/releases/assets/336650203"
 
 [tools.yamlfmt."platforms.macos-arm64"]
 checksum = "sha256:4b417ecb94339d57e4c122ecc948c1a00fe328b5853266de9806e652a92858fa"
 url = "https://github.com/google/yamlfmt/releases/download/v0.21.0/yamlfmt_0.21.0_Darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/google/yamlfmt/releases/assets/336650209"
 
 [[tools.yamllint]]
 version = "1.38.0"
@@ -155,9 +177,11 @@ backend = "aqua:zizmorcore/zizmor"
 [tools.zizmor."platforms.linux-x64"]
 checksum = "sha256:aa1facd105f0d83fe5c55b1adcd9d7417de5d83aa27471f91dc0b66cf3803577"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/421630940"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.macos-arm64"]
 checksum = "sha256:624ef0e09521aecd862126be0f6d7754669af2646750d68ac48a114be33c3146"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.25.2/zizmor-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/421630938"
 provenance = "github-attestations"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 # Minimum `mise` version. If not matched, mise guides the user to update.
 # -> Bump when relying on a newly introduced setting.
-min_version = "2026.6.4" # CVE floor; raise as needed.
+min_version = "2026.6.6" # untrusted-config floor; raise when relying on newer settings.
 
 # ── 🛠️ tools ──────────────────────────────────────────────────────────────────
 # This is a DATA-only Alfred workflow (plist/JSON/SVG/images) — there is NO
@@ -22,7 +22,7 @@ pinact = "4"        # GitHub Actions pin SHAs
 betterleaks = "1"   # secret scanner
 
 # pre-commit
-hk = "1.47.0" # full MAJOR.MINOR.PATCH — git-tag backend (matches `hk init`)
+hk = "1.49.0" # full MAJOR.MINOR.PATCH — must match hk.pkl amends/import URLs
 
 # yamllint ships only via pipx (pure-Python). uv installs it; see pipx.uvx below.
 uv = "0.9"
@@ -122,8 +122,9 @@ run = '[ "$(cat .mise/setup 2>/dev/null)" = "{{vars.setup_version}}" ] || echo "
 
 # ── 🪝 hooks ──────────────────────────────────────────────────────────────────
 [hooks]
-enter = "mise run setup:check"    # nudge users when their setup is stale (see vars.setup_version)
-postinstall = "hk install --mise" # canonical hook install: runs after every `mise install`, idempotent
+# MISE_OFFLINE stops this `mise run` re-resolving tools online on every `cd` (hangs the shell offline).
+enter = "MISE_OFFLINE=1 mise run setup:check"
+postinstall = "hk install --mise"             # canonical hook install: runs after every `mise install`, idempotent
 
 # ── ⚙️ settings ───────────────────────────────────────────────────────────────
 [settings]


### PR DESCRIPTION
### Summary

<!-- pr:summary -->

Hardens the existing mise/hk lint setup and fixes CI so `mise run check --pr` actually diffs against the PR base (no more vacuous green).

**Changes** <!-- pr:changes -->

- **Fixed**: lint CI now sets `origin/HEAD` via `git remote set-head` (the old `git branch --force` left `--pr` checking 0 files)
- **Updated**: hk `1.47.0` → `1.49.0` (and matching `hk.pkl` amends), `min_version` → `2026.6.6`
- **Updated**: `enter` hook wraps `setup:check` in `MISE_OFFLINE=1`
- **Updated**: lint workflow matches the reference (`workflow_dispatch` scope input, shared Run check step)
- **Docs**: README mise install prefers brew + activate + `mise doctor`; AGENTS clarifies `.mise/` stamp

> [!NOTE]
> Retrospective `mise run check --all --fix` on this tip is a no-op (tree already clean from #4). No stacked fixes PR.

---

<details><summary>Tests & Validation</summary>

- `mise run check --all` passes locally after these rule changes
- `mise run check --all --fix` produces no file changes
- `hk validate` clean; `mise lock --platform macos-arm64,linux-x64` refreshed for hk 1.49.0

</details>

### Relevant Links

<!-- pr:links -->

- Stacked onto `main` (CI PR #5 already merged)
- Prior mise migration: #4

---

_<sub>🤝 Created with Cursor (Grok 4.5) on behalf of @sherifabdlnaby, with their input/approval.</sub>_