### PR TITLE
Release preview as a table + Install/Verify footer on releases

### DIFF
--- a/.github/release-footer.md
+++ b/.github/release-footer.md
@@ -1,0 +1,3 @@
+## Install
+
+Download the `.alfredworkflow` asset below and double-click it to import into Alfred.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,12 +112,17 @@ jobs:
               *) echo "" ;;
             esac
           }
+          PREV="$(last_stable)"; [ -z "$PREV" ] && PREV="v0.0.0"
           BUMP="$(bump_of "$LABELS")"
+          # Preview as a table; the marker stays first so the sticky-comment lookup still matches.
           case "$BUMP" in
-            skip) BODY="$MARKER 🏷️ \`skip-release\` — merging this PR cuts no release." ;;
-            "")   BODY="$MARKER ⚠️ No bump label (\`major\`/\`minor\`/\`patch\`/\`skip-release\`) — the gate fails; merged as-is this falls back to \`patch\` → **$(next_version patch)**." ;;
-            *)    BODY="$MARKER 🔖 Merging this PR cuts **$(next_version "$BUMP")** (\`$BUMP\`)." ;;
+            skip) ROW="| \`$PREV\` | \`skip-release\` | — no release |"; NOTE="" ;;
+            "")   ROW="| \`$PREV\` | ⚠️ none | \`patch\` fallback → **\`$(next_version patch)\`** |"
+                  NOTE="> ⚠️ No bump label (\`major\`/\`minor\`/\`patch\`/\`skip-release\`) — the gate fails; an unlabeled merge falls back to \`patch\`." ;;
+            *)    ROW="| \`$PREV\` | \`$BUMP\` | **\`$(next_version "$BUMP")\`** |"; NOTE="" ;;
           esac
+          BODY="$MARKER"$'\n'"### 🔖 Release preview"$'\n\n'"| Current | Bump | On merge |"$'\n'"|:--|:--|:--|"$'\n'"$ROW"
+          [ -n "$NOTE" ] && BODY="$BODY"$'\n\n'"$NOTE"
           CID="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
             --jq "map(select(.body|startswith(\"$MARKER\")))[0].id // empty" || true)"
           if [ -n "$CID" ]; then
@@ -297,6 +302,26 @@ jobs:
           [ "$DRAFT" = true ] && args+=(--draft)
           # Uploads the bundle and its checksums directly (no third-party upload action).
           gh release create "$TAG" build/* "${args[@]}"
+      # Generated notes say what changed; append a footer telling consumers how to install and verify
+      # the artifact (SKILL.md#publish-sign-attest). Per-repo install steps live in
+      # .github/release-footer.md; the Verify block is generated. Idempotent via a marker.
+      - name: Append Install + Verify footer to the release notes
+        env:
+          TAG: ${{ needs.version.outputs.new_tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          BODY="$(gh release view "$TAG" --repo "$REPO" --json body --jq .body)"
+          case "$BODY" in *'<!-- verify-footer -->'*) echo "footer already present"; exit 0 ;; esac
+          INSTALL=""
+          [ -f .github/release-footer.md ] && INSTALL="$(printf '\n\n%s' "$(cat .github/release-footer.md)")"
+          VERIFY="$(printf '%s\n' '' '<!-- verify-footer -->' '---' '## Verify' '' \
+            'Assets are provenance-attested and checksummed — confirm before use:' '' \
+            '```bash' \
+            "gh attestation verify <asset> --repo $REPO" \
+            'sha256sum --check checksums.txt' \
+            '```')"
+          gh release edit "$TAG" --repo "$REPO" --notes "${BODY}${INSTALL}${VERIFY}"
       - name: Comment on the merged PR
         if: github.event_name == 'push' && needs.version.outputs.pr_number != ''
         env:
@@ -341,11 +366,15 @@ jobs:
               --jq "map(select(.body|startswith(\"$MARKER\")))[0].id // empty")"
             [ -z "$CID" ] && continue
             LABELS="$(gh api "repos/$REPO/issues/$NUM/labels" --jq 'map(.name) | join(",")')"
+            PREV="$(last_stable)"; [ -z "$PREV" ] && PREV="v0.0.0"
             BUMP="$(bump_of "$LABELS")"
             case "$BUMP" in
-              skip) BODY="$MARKER 🏷️ \`skip-release\` — merging this PR cuts no release." ;;
-              "")   BODY="$MARKER ⚠️ No bump label (\`major\`/\`minor\`/\`patch\`/\`skip-release\`) — the gate fails; merged as-is this falls back to \`patch\` → **$(next_version patch)**." ;;
-              *)    BODY="$MARKER 🔖 Merging this PR cuts **$(next_version "$BUMP")** (\`$BUMP\`)." ;;
+              skip) ROW="| \`$PREV\` | \`skip-release\` | — no release |"; NOTE="" ;;
+              "")   ROW="| \`$PREV\` | ⚠️ none | \`patch\` fallback → **\`$(next_version patch)\`** |"
+                    NOTE="> ⚠️ No bump label (\`major\`/\`minor\`/\`patch\`/\`skip-release\`) — the gate fails; an unlabeled merge falls back to \`patch\`." ;;
+              *)    ROW="| \`$PREV\` | \`$BUMP\` | **\`$(next_version "$BUMP")\`** |"; NOTE="" ;;
             esac
+            BODY="$MARKER"$'\n'"### 🔖 Release preview"$'\n\n'"| Current | Bump | On merge |"$'\n'"|:--|:--|:--|"$'\n'"$ROW"
+            [ -n "$NOTE" ] && BODY="$BODY"$'\n\n'"$NOTE"
             gh api -X PATCH "repos/$REPO/issues/comments/$CID" -f body="$BODY" >/dev/null
           done


### PR DESCRIPTION
### Summary

<!-- pr:summary -->

Port two release-workflow refinements from the cicd skill asset: the bump-preview sticky comment becomes a markdown table, and releases get an idempotent Install + Verify footer.

**Changes** <!-- pr:changes -->

- **Bump preview → markdown table.** The sticky bump-preview comment (both the autolabel gate and the post-release refresh step) now renders `| Current | Bump | On merge |` under a `### 🔖 Release preview` heading. The `<!-- bump-preview -->` marker still leads the body so the sticky-comment lookup keeps matching.
- **Install + Verify footer on releases.** A new step after `gh release create` stamps an idempotent `<!-- verify-footer -->` block onto the generated notes: per-repo install text from the new `.github/release-footer.md` (download the `.alfredworkflow`, double-click to import) plus a generated Verify block (attestation + checksums).

**Review guide** <!-- pr:review-guide -->

The whole diff is in `.github/workflows/release.yml` (two `case` blocks retabled + one new step) plus the new `.github/release-footer.md`. The table/footer strings are copied verbatim from the cicd skill asset.

<details><summary>Tests & Validation</summary>

`actionlint`, `zizmor`, and the full `mise run check` suite all pass locally.

</details>

### Relevant Links

<!-- pr:links -->

Follow-up to #7 (auto-tag-on-merge migration), which merged and cut v1.1.2 before these two skill-asset refinements landed.

---

_<sub>🤝 Human Guided: Created with Claude (Opus 4.8) on behalf of @sherifabdlnaby.</sub>_