### PR TITLE
Align CI/CD with cicd skill audit shape

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CI / toolchain owners — paired with the branch ruleset requiring a review on these paths.
+.github/ @sherifabdlnaby
+mise.toml @sherifabdlnaby
+mise.lock @sherifabdlnaby
+hk.pkl @sherifabdlnaby

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,77 +1,32 @@
+# Contributing
 
-# Contributor Covenant Code of Conduct
+Thanks for your interest in contributing! Please read the [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
 
-## Our Pledge
+## How to Contribute
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to make participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
 
-## Our Standards
+## Development Setup
 
-Examples of behavior that contributes to creating a positive environment
-include:
+This is a **data-only** Alfred workflow (JSON + assets, no language runtime). The project uses [mise](https://mise.jdx.dev/) for tooling.
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+```bash
+mise trust && mise run setup   # install tools, install git hooks
+mise run check                 # lint / format / validate (add --fix to auto-fix)
+mise run build                 # zip the .alfredworkflow
+mise run clean                 # remove build/
+```
 
-Examples of unacceptable behavior by participants include:
+## Pull Requests
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
-
-## Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
-
-## Scope
-
-This Code of Conduct applies within all project spaces, and it also applies when
-an individual is representing the project or its community in public spaces.
-Examples of representing a project or community include using an official
-project e-mail address, posting via an official social media account, or acting
-as an appointed representative at an online or offline event. Representation of
-a project may be further defined and clarified by project maintainers.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
-
-[homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see
-<https://www.contributor-covenant.org/faq>
+- Keep changes focused and atomic
+- Use descriptive PR titles (they feed into release notes)
+- Add **one bump label** so the release gate knows what to cut on merge:
+  - `major` / `minor` / `patch` — semver bump
+  - `skip-release` — merge without tagging (CI, docs-only, chore)
+- Category labels (`feature`, `bug`, `docs`, `ci`, …) group the generated release notes; the autolabeler applies many of them from the title/files
+- Unlabeled merges fall back to `minor` (the gate fails on the PR so this is the escape hatch, not the happy path)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Dependabot: version updates for Actions pins (data-only repo — no pip/npm).
+# Cooldown waits out the compromised-fresh-release window; groups collapse noise into one PR.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels: [auto-update, skip-release]
+    commit-message:
+      prefix: "ci"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,8 +1,11 @@
-# release-drafter config, used by release.yml's `autolabel` job: the autolabeler sub-action runs it to
-# apply CATEGORY labels (enhancement/bug/docs...) on PRs, and the sibling .github/release.yml (GitHub's
-# native notes config) makes `gh release create --generate-notes` group by them. The version is computed
-# by release.yml's hand-rolled bump, so the version-resolver below stays commented (an active resolver
-# the bump ignores is drift bait). Keep the category labels in sync with .github/release.yml.
+# release-drafter config for the auto-tag model (release.yml):
+#   - the `autolabel` job runs the autolabeler sub-action against this file to apply
+#     category labels; `.github/release.yml` makes `gh release create --generate-notes`
+#     group by them. Version bump is computed by release.yml, so the version-resolver
+#     below stays commented (an active resolver the hand-rolled bump ignores is drift bait).
+#
+# Keep three sets consistent: category labels here, release.yml changelog categories,
+# and bump labels (major/minor/patch/skip-release) handled only by release.yml.
 categories:
   - title: "🚀 Enhancements"
     labels: ["enhancement", "feature"]
@@ -10,13 +13,19 @@ categories:
     labels: ["upgrades"]
   - title: "🐛 Bug Fixes"
     labels: ["fix", "bug", "hotfix"]
+  - title: "⚙️ CI & Build"
+    labels: ["ci", "build"]
   - title: "🤖 Automatic Updates"
     labels: ["auto-update"]
   - title: "📝 Documentation"
     labels: ["docs"]
 autolabeler:
   - label: "docs"
-    files: ["*.md"]
+    files: ["**/*.md"]
+    title: ['/\bdocs?\b|readme/i']
+  - label: "ci"
+    files: [".github/**", "mise.toml", "mise.lock", "hk.pkl"]
+    title: ['/\bci\b|workflow|pipeline|actions/i']
   - label: "enhancement"
     title: ["/enhancement/i"]
   - label: "upgrades"
@@ -37,12 +46,11 @@ template: |
   ## Changes
 
   $CHANGES
-# The auto-tag model in release.yml owns the version, so release-drafter never resolves it here.
-# Uncomment only if you switch back to the draft-then-publish model (auto-release workflow):
+# DRAFT model only — uncomment so release-drafter resolves the version from bump labels:
 # name-template: "v$RESOLVED_VERSION 🚀"
 # tag-template: "v$RESOLVED_VERSION"
 # version-resolver:
 #   major: { labels: ["major"] }
 #   minor: { labels: ["minor", "enhancement", "feature"] }
-#   patch: { labels: ["patch", "fix", "bug", "chore", "auto-update"] }
-#   default: patch
+#   patch: { labels: ["patch", "fix", "bug", "chore", "auto-update", "ci"] }
+#   default: minor

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,7 +1,6 @@
-# GitHub's NATIVE generated-release-notes config (this exact path is required; not a workflow — the
-# release workflow is workflows/release.yml). `gh release create --generate-notes` groups entries by
-# these categories; without this file the notes are a flat list and the autolabeler's category labels
-# decorate nothing. Keep the labels in sync with release-drafter.yml (the autolabeler that applies them).
+# GitHub's NATIVE generated-release-notes config (this exact path is required; not a workflow —
+# the release workflow is workflows/release.yml). `gh release create --generate-notes` groups
+# entries by these categories. Keep in sync with release-drafter.yml (the autolabeler).
 changelog:
   categories:
     - title: 🚀 Enhancements
@@ -10,6 +9,8 @@ changelog:
       labels: [upgrades]
     - title: 🐛 Bug Fixes
       labels: [fix, bug, hotfix]
+    - title: ⚙️ CI & Build
+      labels: [ci, build]
     - title: 🤖 Automatic Updates
       labels: [auto-update]
     - title: 📝 Documentation

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,7 @@
 # Drives the project's own `mise run check` (the same task local dev + the pre-commit
 # hook use) and reports lint/format failures. On a PR it leaves one sticky comment
-# pointing the author at `mise run check --fix`. See references/ci.md.
+# pointing the author at `mise run check --fix`. Also validates `mise run build` so a
+# broken package cannot merge undetected. See references/platforms/github.md (cicd skill).
 name: 🎨 Linters, Validators, and Formatters
 on:
   pull_request: {}
@@ -15,10 +16,9 @@ on:
         type: choice
         options: [all, pr]
         default: all
-# Read the repo; comment on PRs to point the author at the fix command.
+# Default read-only; the check job widens to comment on PRs.
 permissions:
   contents: read
-  pull-requests: write
 # One run per PR (or ref) — newer pushes cancel stale runs.
 concurrency:
   group: lint-${{ github.event.pull_request.number || github.ref }}
@@ -27,6 +27,10 @@ jobs:
   check:
     name: check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write # sticky comment pointing the author at the fix command
     env:
       # Pretty colors in the CI!
       CLICOLOR_FORCE: "1"
@@ -58,10 +62,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # used by pinact to verify pinned action annotations
         run: |
           # PRs check changed files (--pr); schedule/dispatch default to --all (dispatch can pick --pr).
-          [ "$EVENT" = pull_request ] && scope="pr" || scope="${SCOPE_INPUT:-all}"
+          if [ "$EVENT" = "pull_request" ]; then
+            scope="pr"
+          else
+            scope="${SCOPE_INPUT:-all}"
+          fi
           # hk's --pr resolves the base via origin/HEAD, which the Actions checkout never sets; point it
           # at the PR base so hk diffs origin/<base>...HEAD (else it finds 0 files and passes green).
-          [ "$scope" = "pr" ] && git remote set-head origin "$BASE_REF" >/dev/null 2>&1 || true
+          if [ "$scope" = "pr" ]; then
+            git remote set-head origin "$BASE_REF" >/dev/null 2>&1 || true
+          fi
           mise run check "--$scope" || {
             echo "::error::Lint & format failed on $REF_NAME — fix locally with 'mise run check --fix --$scope', then push. ('mise run setup' installs the pre-commit hook so this happens on every commit.)"
             exit 1
@@ -98,3 +108,30 @@ jobs:
             } else if (existing) {
               await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
             }
+  # Smoke-test the packaged artifact on every PR / schedule so a broken build cannot merge.
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Setup mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          install_args: "--locked"
+          cache: true
+          experimental: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build .alfredworkflow
+        run: |
+          set -euo pipefail
+          # Throwaway version stamp; release.yml stamps the real tag on publish.
+          mise run build --version v0.0.0-ci
+          test -f build/alfred-granted-v0.0.0-ci.alfredworkflow

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -1,0 +1,59 @@
+# Community janitors (stale PRs + lock closed threads).
+# First landing is observe-only: stale runs in debug-only (no closes); lock stays
+# gated behind repo variable COMMUNITY_ARM=true until armed after a few sweeps.
+name: Community
+on:
+  schedule:
+    - cron: "0 12 * * *" # daily noon UTC
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: community
+  cancel-in-progress: false
+jobs:
+  stale:
+    name: stale
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
+        with:
+          # Observe-only until armed: set debug-only to false after a few dry runs look right.
+          debug-only: true
+          days-before-issue-stale: -1 # issues disabled on this repo; never stale issues
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          exempt-pr-labels: pinned,security
+          operations-per-run: 30
+          stale-pr-message: >
+            This PR has been idle for a while. Marking it stale — rebase and push (or comment) to keep it alive, or it will close in two weeks. Reopen anytime.
+
+          close-pr-message: >
+            Closing as stale. Reopen when you're ready to rebase and continue.
+
+  lock:
+    name: lock
+    # Arm by setting repo variable COMMUNITY_ARM=true (Settings → Variables).
+    if: ${{ vars.COMMUNITY_ARM == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
+        with:
+          process-only: "prs"
+          pr-inactive-days: "90"
+          pr-lock-reason: "resolved"
+          pr-comment: >
+            Locking this closed PR after 90 days of inactivity. Open a new issue or PR that links back here if you still need something.
+
+          log-output: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,16 @@
 name: Release
-# PR merge → semver tag → build .alfredworkflow → attest → publish, notes generated.
-# Auto-tag-on-merge model: the merged PR's bump label decides the version; the pipeline tags,
-# builds, attests, and publishes from the merge. Linting is a separate workflow (lint.yml).
+# Default (hand-rolled) release front-end: PR merge -> semver tag -> build -> publish, notes generated.
+# Copy and adapt. The build/publish back-end here is the "packaged artifact" shape (`mise run build`
+# + attach to the Release). Container images FOLD publish-sign.yml's push/sign/attest steps into the
+# release job below (a GITHUB_TOKEN-created release does not fire `release: published`, so the two
+# files won't chain on their own); Go binaries use GoReleaser — see the cicd runtime references.
+# Linting is a separate workflow (check.yml).
 #
 # The version contract (this file is the single source of truth for it):
 #   open PR ........................ bump gate: no bump label fails the job; a sticky comment previews
 #                                    the exact tag a merge would cut (refreshed after each stable release)
-#   merged PR, no bump label ....... default `patch` (the gate's fallback when merged anyway)
+#   merged PR, no bump label ....... default `minor` (the gate's fallback when merged anyway;
+#                                    patch is too easy to ship by accident, major is costly under immutable releases)
 #   merged PR, multiple labels ..... precedence major > minor > patch
 #   `skip-release` label ........... abort, cut nothing
 #   dispatch, explicit `version` ... use verbatim (via env, never interpolated); v-prefixed if missing
@@ -34,8 +38,8 @@ on:
         description: "Bump when no explicit version is given."
         required: false
         type: choice
-        options: [patch, minor, major]
-        default: patch
+        options: [minor, patch, major]
+        default: minor
       prerelease:
         description: "Cut a release candidate (-rc.N) of the computed bump."
         required: false
@@ -59,10 +63,11 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   # ── Autolabel PRs + bump gate/preview (category labels for the notes; nothing is released here) ──
-  # Fork PRs carry a read-only token, so labeling/commenting 403s there — acceptable for a solo repo;
+  # Fork PRs carry a read-only token, so labeling/commenting 403s there — acceptable for solo repos;
   # the gate still fails the run. (pull_request_target would fix the 403 but runs with elevated
   # permissions; avoid unless you need it.)
   autolabel:
+    timeout-minutes: 15
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
@@ -81,7 +86,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Bump gate + version preview: one sticky comment shows the exact tag a merge would cut,
       # recomputed on every label change; no bump label fails the job (make it a required check to
-      # enforce — release runs still fall back to `patch` if an unlabeled PR merges anyway).
+      # enforce — release runs still fall back to `minor` if an unlabeled PR merges anyway).
       - name: Bump gate & version preview
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -92,9 +97,8 @@ jobs:
           set -euo pipefail
           MARKER="<!-- bump-preview -->"
           # Keep in sync with the release job's "Refresh bump previews" step.
-          last_stable() { git tag -l 'v*' --sort=-v:refname | grep -v '-' | head -1 || true; }
-          next_version() { # $1 = bump
-            PREV="$(last_stable)"; [ -z "$PREV" ] && PREV="v0.0.0"
+          last_stable() { t="$(git tag -l 'v*' --sort=-v:refname | grep -v '-' | head -1 || true)"; echo "${t:-v0.0.0}"; }
+          next_version() { # $1 = bump (reads $PREV)
             IFS='.' read -r MA MI PA <<< "${PREV#v}"
             case "$1" in
               major) MA=$((MA + 1)); MI=0; PA=0 ;;
@@ -112,14 +116,15 @@ jobs:
               *) echo "" ;;
             esac
           }
-          PREV="$(last_stable)"; [ -z "$PREV" ] && PREV="v0.0.0"
+          PREV="$(last_stable)"
           BUMP="$(bump_of "$LABELS")"
           # Preview as a table; the marker stays first so the sticky-comment lookup still matches.
+          NOTE=""
           case "$BUMP" in
-            skip) ROW="| \`$PREV\` | \`skip-release\` | — no release |"; NOTE="" ;;
-            "")   ROW="| \`$PREV\` | ⚠️ none | \`patch\` fallback → **\`$(next_version patch)\`** |"
-                  NOTE="> ⚠️ No bump label (\`major\`/\`minor\`/\`patch\`/\`skip-release\`) — the gate fails; an unlabeled merge falls back to \`patch\`." ;;
-            *)    ROW="| \`$PREV\` | \`$BUMP\` | **\`$(next_version "$BUMP")\`** |"; NOTE="" ;;
+            skip) ROW="| \`$PREV\` | \`skip-release\` | — no release |" ;;
+            "")   ROW="| \`$PREV\` | ⚠️ none | \`minor\` fallback → **\`$(next_version minor)\`** |"
+                  NOTE="> ⚠️ No bump label (\`major\`/\`minor\`/\`patch\`/\`skip-release\`) — the gate fails; an unlabeled merge falls back to \`minor\`." ;;
+            *)    ROW="| \`$PREV\` | \`$BUMP\` | **\`$(next_version "$BUMP")\`** |" ;;
           esac
           BODY="$MARKER"$'\n'"### 🔖 Release preview"$'\n\n'"| Current | Bump | On merge |"$'\n'"|:--|:--|:--|"$'\n'"$ROW"
           [ -n "$NOTE" ] && BODY="$BODY"$'\n\n'"$NOTE"
@@ -133,7 +138,7 @@ jobs:
               || echo "::warning::could not post the preview comment (fork PR?)"
           fi
           if [ -z "$BUMP" ]; then
-            echo "::error::No bump label (major/minor/patch/skip-release) on this PR — add one; an unlabeled merge falls back to patch."
+            echo "::error::No bump label (major/minor/patch/skip-release) on this PR — add one; an unlabeled merge falls back to minor."
             exit 1
           fi
   # ── Resolve the next version from labels or dispatch inputs ──
@@ -173,12 +178,13 @@ jobs:
           LABELS=$(echo "$PR_JSON" | jq -r '[.labels[].name] | join(",")')
           echo "number=$(echo "$PR_JSON" | jq -r '.number')" >> "$GITHUB_OUTPUT"
           # Exact label match (grep -w would also hit e.g. `major-redesign`).
-          # Precedence skip-release > major > minor > patch; default patch.
+          # Precedence skip-release > major > minor > patch; unlabeled default minor.
           case ",${LABELS}," in
             *,skip-release,*) echo "skip=true"   >> "$GITHUB_OUTPUT"; exit 0 ;;
             *,major,*)        echo "bump=major"  >> "$GITHUB_OUTPUT" ;;
             *,minor,*)        echo "bump=minor"  >> "$GITHUB_OUTPUT" ;;
-            *)                echo "bump=patch"  >> "$GITHUB_OUTPUT" ;;
+            *,patch,*)        echo "bump=patch"  >> "$GITHUB_OUTPUT" ;;
+            *)                echo "bump=minor"  >> "$GITHUB_OUTPUT" ;;
           esac
       - name: Compute next version
         if: >-
@@ -201,7 +207,7 @@ jobs:
             NEW_TAG="${INPUT_VERSION}"; [ "${NEW_TAG#v}" = "${NEW_TAG}" ] && NEW_TAG="v${NEW_TAG}"
           else
             # 2) Otherwise bump the latest stable. Bump source: PR label (push) or dispatch input.
-            BUMP="${LABEL_BUMP:-${INPUT_BUMP:-patch}}"
+            BUMP="${LABEL_BUMP:-${INPUT_BUMP:-minor}}"
             PREV="$(last_stable)"; [ -z "$PREV" ] && PREV="v0.0.0"
             IFS='.' read -r MA MI PA <<< "${PREV#v}"; PA="${PA%%-*}"
             case "$BUMP" in
@@ -233,8 +239,9 @@ jobs:
             echo "notes_start=$NOTES_START"
           } >> "$GITHUB_OUTPUT"
           echo "Resolved: $NEW_TAG (prerelease=$PRE, notes-start='${NOTES_START}')"
-  # ── Tag, build, attest, publish ──
+  # ── Tag, build, publish, attest ──
   release:
+    timeout-minutes: 15
     needs: version
     if: needs.version.outputs.new_tag != ''
     runs-on: ubuntu-latest
@@ -271,17 +278,17 @@ jobs:
           experimental: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # so tool installs don't hit API rate limits
-      - name: Build artifacts
+      - name: Build .alfredworkflow
         env:
           VERSION: ${{ needs.version.outputs.new_tag }}
         run: |
           set -euo pipefail
-          # Same build task local dev runs; it stamps VERSION and drops the .alfredworkflow under build/.
+          # Same build task local dev runs; --version stamps the tag into info.plist.
           mise run build --version "${VERSION}"
-          ( cd build && sha256sum ./* > checksums.txt )
+          # Checksum the bundle only (not checksums.txt itself).
+          ( cd build && sha256sum ./*.alfredworkflow > checksums.txt )
       # Provenance for every published artifact (the checksums file covers the set). The principle is
-      # artifact-agnostic: bundles get attested just like images do. Consumers verify with
-      # `gh attestation verify <file> --owner sherifabdlnaby` (documented in the README).
+      # artifact-agnostic: bundles get attested just like images do.
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
@@ -300,7 +307,6 @@ jobs:
           elif [ "$DRAFT" != true ]; then args+=(--latest); fi
           [ -n "$NOTES_START" ] && args+=(--notes-start-tag "$NOTES_START")
           [ "$DRAFT" = true ] && args+=(--draft)
-          # Uploads the bundle and its checksums directly (no third-party upload action).
           gh release create "$TAG" build/* "${args[@]}"
       # Generated notes say what changed; append a footer telling consumers how to install and verify
       # the artifact (SKILL.md#publish-sign-attest). Per-repo install steps live in
@@ -329,7 +335,13 @@ jobs:
           PR_NUMBER: ${{ needs.version.outputs.pr_number }}
           REPO: ${{ github.repository }}
         run: |
-          gh pr comment "$PR_NUMBER" --body "🚀 **Release ${TAG}** published: https://github.com/${REPO}/releases/tag/${TAG}"
+          set -euo pipefail
+          gh pr comment "$PR_NUMBER" --body "🚀 **Release ${TAG}** published: https://github.com/${REPO}/releases/tag/${TAG}
+
+          Verify the bundle's provenance before installing:
+          \`\`\`bash
+          gh attestation verify alfred-granted-${TAG}.alfredworkflow --owner sherifabdlnaby
+          \`\`\`"
       # The base version just moved, so open PRs' bump previews are stale — recompute them. Stable
       # releases only (an rc doesn't move the last stable). Updates existing preview comments only;
       # a PR gets its first one from its own PR events (the autolabel job).
@@ -341,9 +353,8 @@ jobs:
           set -euo pipefail
           MARKER="<!-- bump-preview -->"
           # Keep in sync with the autolabel job's "Bump gate & version preview" step.
-          last_stable() { git tag -l 'v*' --sort=-v:refname | grep -v '-' | head -1 || true; }
-          next_version() { # $1 = bump
-            PREV="$(last_stable)"; [ -z "$PREV" ] && PREV="v0.0.0"
+          last_stable() { t="$(git tag -l 'v*' --sort=-v:refname | grep -v '-' | head -1 || true)"; echo "${t:-v0.0.0}"; }
+          next_version() { # $1 = bump (reads $PREV)
             IFS='.' read -r MA MI PA <<< "${PREV#v}"
             case "$1" in
               major) MA=$((MA + 1)); MI=0; PA=0 ;;
@@ -361,18 +372,19 @@ jobs:
               *) echo "" ;;
             esac
           }
+          PREV="$(last_stable)"
           gh pr list --state open --json number --jq '.[].number' | while read -r NUM; do
             CID="$(gh api "repos/$REPO/issues/$NUM/comments" \
               --jq "map(select(.body|startswith(\"$MARKER\")))[0].id // empty")"
             [ -z "$CID" ] && continue
             LABELS="$(gh api "repos/$REPO/issues/$NUM/labels" --jq 'map(.name) | join(",")')"
-            PREV="$(last_stable)"; [ -z "$PREV" ] && PREV="v0.0.0"
             BUMP="$(bump_of "$LABELS")"
+            NOTE=""
             case "$BUMP" in
-              skip) ROW="| \`$PREV\` | \`skip-release\` | — no release |"; NOTE="" ;;
-              "")   ROW="| \`$PREV\` | ⚠️ none | \`patch\` fallback → **\`$(next_version patch)\`** |"
-                    NOTE="> ⚠️ No bump label (\`major\`/\`minor\`/\`patch\`/\`skip-release\`) — the gate fails; an unlabeled merge falls back to \`patch\`." ;;
-              *)    ROW="| \`$PREV\` | \`$BUMP\` | **\`$(next_version "$BUMP")\`** |"; NOTE="" ;;
+              skip) ROW="| \`$PREV\` | \`skip-release\` | — no release |" ;;
+              "")   ROW="| \`$PREV\` | ⚠️ none | \`minor\` fallback → **\`$(next_version minor)\`** |"
+                    NOTE="> ⚠️ No bump label (\`major\`/\`minor\`/\`patch\`/\`skip-release\`) — the gate fails; an unlabeled merge falls back to \`minor\`." ;;
+              *)    ROW="| \`$PREV\` | \`$BUMP\` | **\`$(next_version "$BUMP")\`** |" ;;
             esac
             BODY="$MARKER"$'\n'"### 🔖 Release preview"$'\n\n'"| Current | Bump | On merge |"$'\n'"|:--|:--|:--|"$'\n'"$ROW"
             [ -n "$NOTE" ] && BODY="$BODY"$'\n\n'"$NOTE"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,3 @@
+# Repo-wide zizmor exceptions. Prefer inline `# zizmor: ignore[<rule>] -- <why>` on the
+# offending line; only put lasting, repo-wide exceptions here with a written justification.
+rules: {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ Prefer `mise run <task>` over calling the tool directly, so local, hooks, and CI
 
 Commits run [hk](https://hk.jdx.dev), the same `check` CI runs, to format and lint staged files. Fix failures with `mise run check --fix`. Don't disable steps to push a commit through; `git commit --no-verify` skips hooks for a WIP commit.
 
+## Releases
+
+Merging to `main` with a bump label (`major` / `minor` / `patch`) tags, builds the `.alfredworkflow`, attests provenance, and publishes a GitHub Release. Use `skip-release` when the change should not cut a version. Category labels (`feature`, `bug`, `docs`, `ci`, …) only group the generated notes. Manual RC: Actions → Release → `prerelease: true`.
+
 ## Project notes
 
 - The workflow is **data + assets only**: `info.plist`, `regions.json`, `services.json`, `services/*.svg`, `icon.png`, `region.png`. Add/extend an account, region, or service by editing the JSON and (for a new service) dropping its `.svg` icon under `services/` — no code involved.
@@ -39,6 +43,6 @@ Changing tools, tasks, env, or hooks? Edit the config, don't bolt on scripts, th
 - **`mise.lock`**: resolved versions plus checksums. Commit it; regenerate with `mise install` then `mise lock --platform macos-arm64,linux-x64` after a `[tools]` change.
 - **`.mise/`**: project-local state (the `setup` stamp is gitignored; the directory is committed so the stamp has a home).
 - **`hk.pkl`**: the pre-commit and `check` pipeline (linters and formatters, in Pkl). Add or edit a lint step here.
-- Linter config scaffolds live at the repo root (`typos.toml`, `.betterleaks.toml`, `lychee.toml`, `rumdl.toml`, `.yamllint`).
+- Linter config scaffolds live at the repo root (`typos.toml`, `.betterleaks.toml`, `lychee.toml`, `rumdl.toml`, `.yamllint`) and `.github/zizmor.yml`.
 
 For tool, task, and hook syntax, see the [mise](https://mise.jdx.dev) and [hk](https://hk.jdx.dev) docs.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ mise doctor
    mise run <task> --help  # a task's flags
    ```
 
-Commits automatically run the same `check` pipeline on staged files via hk. Fix any failures with `mise run check --fix`. CI runs `mise run check` on every PR. Releases are label-driven: the `major`/`minor`/`patch`/`skip-release` label on a merged PR bumps the version, and the pipeline tags it, builds the `.alfredworkflow`, attests its provenance, and publishes the release automatically.
+Commits automatically run the same `check` pipeline on staged files via hk. Fix any failures with `mise run check --fix`. CI runs `mise run check` (and a build smoke) on every PR. Releases are label-driven: add one of `major` / `minor` / `patch` / `skip-release` on the PR; merging tags, builds the `.alfredworkflow`, attests provenance, and publishes. Unlabeled merges fall back to `minor`.
 
 See [`AGENTS.md`](./AGENTS.md) for how to extend the data/tooling (including for AI agents).
 


### PR DESCRIPTION
### Summary

<!-- pr:summary -->

Full CI/CD audit for alfred-aws-granted: match the alfred-repos cicd-fy shape (report-only checks, minor unlabeled fallback, hygiene companions).

**Changes** <!-- pr:changes -->

- Rename `lint.yml` → `check.yml` and add a PR `build` smoke job (`mise run build`)
- Flip unlabeled release fallback `patch` → `minor` (explicit `patch` label still works)
- Sync `release-drafter.yml` + `.github/release.yml` notes (ci/build category, autolabeler paths)
- Add Dependabot (github-actions only), CODEOWNERS, community janitors (dry-run), `.github/zizmor.yml`
- Replace CoC-duplicate CONTRIBUTING with real contributing docs; AGENTS Releases section; README release cut note

> [!IMPORTANT]
> Repo settings applied outside this diff: seeded bump/category labels, delete-branch-on-merge, default workflow permissions `read`, Dependabot security updates, and an updated `Protect main` ruleset requiring `check` / `build` / `autolabel`.

**Review guide** <!-- pr:review-guide -->

Start with `.github/workflows/release.yml` and `.github/workflows/check.yml`, then Dependabot/community/CODEOWNERS.

<details><summary>Tests & Validation</summary>

- `mise run check --all --fix` (clean)
- `mise run build --version v0.0.0-ci` → `build/alfred-granted-v0.0.0-ci.alfredworkflow`
- actionlint + zizmor + pinact via hk

</details>

### Relevant Links

<!-- pr:links -->

Related: [alfred-repos#11](https://github.com/sherifabdlnaby/alfred-repos/pull/11)

---

_<sub>🤖 Agent Decided PR: Created with Cursor (Grok 4.5) on behalf of @sherifabdlnaby.</sub>_