### PR TITLE
Fix Dependabot github-actions cooldown config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,8 @@ updates:
     schedule:
       interval: weekly
     cooldown:
+      # Actions tags are not SemVer-typed; only default-days is valid here.
       default-days: 7
-      semver-major-days: 14
     groups:
       github-actions:
         patterns: ["*"]


### PR DESCRIPTION
### Summary

<!-- pr:summary -->

Drop `semver-major-days` from the `github-actions` Dependabot cooldown. Dependabot rejects it (Actions tags are not SemVer-typed), which left `.github/dependabot.yml` failing on `main`.

**Changes** <!-- pr:changes -->

Not applicable: this PR contains one focused change.

**Review guide** <!-- pr:review-guide -->

Not applicable: the diff is small and can be reviewed linearly.

### Relevant Links

<!-- pr:links -->

Not applicable: no relevant external links.

---

_<sub>🤖 Agent Decided PR: Created with Cursor (Grok 4.5) on behalf of @sherifabdlnaby.</sub>_