### PR TITLE
Fix zizmor ignore placement for Dependabot action bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       # Keeps the checkout token: the next step pushes the tag with it.
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 # zizmor: ignore[artipacked] -- this job pushes the release tag
+      - name: Checkout # zizmor: ignore[artipacked] -- this job pushes the release tag with the checkout token
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Create and push tag


### PR DESCRIPTION
### Summary

<!-- pr:summary -->

Move the `artipacked` zizmor ignore off the release Checkout `uses:` line onto the step `name:` so Dependabot can rewrite the `# vX.Y.Z` comment when it bumps SHAs. Keeps zizmor + pinact behavior intact.

**Changes** <!-- pr:changes -->

Not applicable: this PR contains one focused change.

**Review guide** <!-- pr:review-guide -->

Not applicable: the diff is small and can be reviewed linearly.

### Relevant Links

<!-- pr:links -->

Not applicable: no relevant external links.

---

_<sub>🤖 Agent Decided PR: Created with Cursor (Grok 4.5) on behalf of @sherifabdlnaby.</sub>_